### PR TITLE
Add faizalmy/manifoldbot to alternatives list

### DIFF
--- a/ALTERNATIVES.md
+++ b/ALTERNATIVES.md
@@ -143,6 +143,26 @@ Below are community-built bots that take this pattern in different directions. F
 
 ---
 
+## `manifoldbot` (faizalmy)
+
+**Repo:** https://github.com/faizalmy/manifoldbot
+
+**What it is:** Multi-agent trading bot built on Google ADK (Agent Development Kit) with specialized agents for market analysis, risk assessment, and decision-making using consensus mechanisms.
+
+**Novelty vs `manifoldbot`:**
+
+- Multi-agent architecture with specialized agents (MarketAnalysisAgent, RiskAssessmentAgent, CoordinatorAgent) using Google ADK
+- Chain-of-thought reasoning with transparent, auditable decision-making
+- External data source integration (Exa, Perplexity, Tavily) for real-time information access
+- Consensus-based decision-making through weighted voting across agents
+- Production-ready features: continuous operation mode, graceful shutdown, configuration validation
+- Comprehensive performance tracking (realized/unrealized P&L, win rate, risk-adjusted metrics)
+- Model-agnostic LLM access via LiteLLM (OpenAI, Ollama) through Google ADK
+
+**Best for:** Users wanting a production-grade multi-agent system with external data integration and transparent reasoning.
+
+---
+
 ### Full list of alternatives (feel free to add more)
 
 - https://github.com/sachin-detrax/better_manifold_bot
@@ -153,3 +173,4 @@ Below are community-built bots that take this pattern in different directions. F
 - https://github.com/101jayjoshi-sudo/bot-
 - https://github.com/blackXmask/Manifold-Markets-Trading-Bot
 - https://github.com/Djmon007/mikhailtal-s-market-master
+- https://github.com/faizalmy/manifoldbot


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new alternative entry for `faizalmy/manifoldbot`.
> 
> - Describes a Google ADK-based multi-agent trading bot with specialized agents and consensus decision-making
> - Highlights features: chain-of-thought reasoning, external data integration, weighted voting, continuous operation, graceful shutdown, config validation
> - Notes comprehensive performance tracking and model-agnostic LLM access via LiteLLM
> - Includes a concise “Best for” section
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b2ee86176950cea1b18184f8126d09c152271d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->