### PR TITLE
Add manifold_mikhail_bot to ALTERNATIVES

### DIFF
--- a/ALTERNATIVES.md
+++ b/ALTERNATIVES.md
@@ -6,13 +6,15 @@ This repository (`microprediction/manifoldbot`) is a general-purpose Python pack
 Below are community-built bots that take this pattern in different directions. For each one, the focus is on **what’s novel relative to `manifoldbot`** rather than just re-implementing the same thing.
 
 ---
-- [manifold_mikhail_bot] 
-repo: https://github.com/mostafazhrn/manifold_mikhail_bot
-A Python-based, GUI-enabled Manifold trading bot that targets markets created by
-MikhailTal, combining classical machine-learning models with LLM-based reasoning
-(local models or OpenAI API), optionally augmented with web-search analysis, to produce
-probability estimates and automated trades.
-Novelty vs manifoldbot:
+## manifold_mikhail_bot
+Repo: https://github.com/mostafazhrn/manifold_mikhail_bot
+
+**What it is:**  
+A Python-based, GUI-enabled Manifold trading bot that targets markets created by MikhailTal,  
+combining classical machine-learning models with LLM-based reasoning (local models or OpenAI API),  
+optionally augmented with web-search analysis, to produce probability estimates and automated trades.
+
+#### Novelty vs manifoldbot:
 - Explicit ML training pipeline on resolved Manifold markets with per-option probability outputs
 - Probability calibration that respects and incorporates live market probabilities rather than ignoring them
 - Risk-aware final decision layer that blends ML estimates and LLM reasoning to gate and size trades conservatively
@@ -21,7 +23,8 @@ Novelty vs manifoldbot:
 - GUI-first design for strategy configuration, live monitoring, and experimentation
 - Designed for extensibility beyond a single creator (default: MikhailTal)
 
-Best for: Users who want a flexible, GUI-driven Manifold bot that blends traditional ML
+**Best for:**  
+Users who want a flexible, GUI-driven Manifold bot that blends traditional machine learning  
 with optional local or API-based LLM reasoning.
 
 ---

--- a/ALTERNATIVES.md
+++ b/ALTERNATIVES.md
@@ -6,7 +6,25 @@ This repository (`microprediction/manifoldbot`) is a general-purpose Python pack
 Below are community-built bots that take this pattern in different directions. For each one, the focus is on **what’s novel relative to `manifoldbot`** rather than just re-implementing the same thing.
 
 ---
+- [manifold_mikhail_bot] 
+repo: https://github.com/mostafazhrn/manifold_mikhail_bot
+A Python-based, GUI-enabled Manifold trading bot that targets markets created by
+MikhailTal, combining classical machine-learning models with LLM-based reasoning
+(local models or OpenAI API), optionally augmented with web-search analysis, to produce
+probability estimates and automated trades.
+Novelty vs manifoldbot:
+- Explicit ML training pipeline on resolved Manifold markets with per-option probability outputs
+- Probability calibration that respects and incorporates live market probabilities rather than ignoring them
+- Risk-aware final decision layer that blends ML estimates and LLM reasoning to gate and size trades conservatively
+- Optional reasoning layer using either local LLMs (via Ollama) or hosted APIs (e.g. OpenAI)
+- Web-search–augmented context gathering for markets with external information
+- GUI-first design for strategy configuration, live monitoring, and experimentation
+- Designed for extensibility beyond a single creator (default: MikhailTal)
 
+Best for: Users who want a flexible, GUI-driven Manifold bot that blends traditional ML
+with optional local or API-based LLM reasoning.
+
+---
 ## `better_manifold_bot` (sachin-detrax)
 
 **Repo:** https://github.com/sachin-detrax/better_manifold_bot


### PR DESCRIPTION
This PR adds manifold_mikhail_bot to ALTERNATIVES.md.

manifold_mikhail_bot is an open-source Python Manifold trading bot that participates
exclusively in markets created by MikhailTal. It extends the baseline manifoldbot
with an explicit ML training pipeline on resolved markets, probability calibration
that respects live market probabilities, and an optional LLM-based reasoning layer
(using either local models or hosted APIs), with a GUI for configuration and
monitoring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new alternative bot entry and updates the list of community projects.
> 
> - New `manifold_mikhail_bot` section in `ALTERNATIVES.md` with repo link, short description, and "Novelty vs `manifoldbot`" bullets (ML training pipeline, probability calibration incorporating market odds, risk-aware decision layer blending ML and LLMs, optional local/API LLM reasoning, web-search augmentation, GUI-first design)
> - Appends `https://github.com/mostafazhrn/manifold_mikhail_bot` to the "Full list of alternatives"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da7c759ea70b3bc9f6badfe3fe883bb698747171. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->